### PR TITLE
[WIP]: can manage only Users for now

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,10 @@ import Layout from "./components/Layouts/Layout";
 import LayoutUser from "./components/Layouts/LayoutUser";
 import { ProtectedRoute } from "./components/ProtectedRoutes/ProtectedRoute";
 import { useAuth } from "./contexts/AuthContext";
+import AdminGroups from "./pages/admin/AdminGroups";
+import AdminMain from "./pages/admin/AdminMain";
+import AdminTeams from "./pages/admin/AdminTeams";
+import AdminUsers from "./pages/admin/AdminUsers";
 import ChangeForgotPassword from "./pages/auth/ChangeForgotPassword";
 import ForgotPassword from "./pages/auth/ForgotPassword";
 import SignIn from "./pages/auth/SignIn";
@@ -21,6 +25,7 @@ import About from "./pages/legal/About";
 import Privacy from "./pages/legal/Privacy";
 import Terms from "./pages/legal/Terms";
 import User from "./pages/users/User";
+import { UserRole } from "./types/User";
 
 const App = () => {
 	const { user } = useAuth();
@@ -81,10 +86,81 @@ const App = () => {
 
 					<Route path="/users/:userId" element={<User />} />
 
+					{/* DASHBOARD ADMIN */}
+					<Route
+						path="/admin"
+						element={
+							<ProtectedRoute
+								isAllowed={
+									!!user && user.role === UserRole.ADMIN
+								}
+								redirectPath="/dashboard"
+							>
+								<AdminMain />
+							</ProtectedRoute>
+						}
+					>
+						<Route
+							index
+							element={
+								<ProtectedRoute
+									isAllowed={
+										!!user && user.role === UserRole.ADMIN
+									}
+									redirectPath="/dashboard"
+								>
+									<Navigate to="/admin/users" />
+								</ProtectedRoute>
+							}
+						/>
+						<Route
+							path="users"
+							element={
+								<ProtectedRoute
+									isAllowed={
+										!!user && user.role === UserRole.ADMIN
+									}
+									redirectPath="/dashboard"
+								>
+									<AdminUsers />
+								</ProtectedRoute>
+							}
+						/>
+						<Route
+							path="groups"
+							element={
+								<ProtectedRoute
+									isAllowed={
+										!!user && user.role === UserRole.ADMIN
+									}
+									redirectPath="/dashboard"
+								>
+									<AdminGroups />
+								</ProtectedRoute>
+							}
+						/>
+						<Route
+							path="teams"
+							element={
+								<ProtectedRoute
+									isAllowed={
+										!!user && user.role === UserRole.ADMIN
+									}
+									redirectPath="/dashboard"
+								>
+									<AdminTeams />
+								</ProtectedRoute>
+							}
+						/>
+					</Route>
+
 					{/* LEGAL */}
 					<Route path="/about" element={<About />} />
 					<Route path="/terms-and-conditions" element={<Terms />} />
 					<Route path="/privacy-policy" element={<Privacy />} />
+
+					{/* REDIRECT */}
+					<Route path="*" element={<Navigate to="/" />} />
 				</Route>
 
 				<Route element={<LayoutUser />}>

--- a/client/src/api/user.ts
+++ b/client/src/api/user.ts
@@ -16,6 +16,19 @@ export const getUser = async (userId: string) => {
 	return await response.json();
 };
 
+export const getAllUsers = async () => {
+	const response = await fetchWithRefreshAndRetry(
+		`${keys.API_URL}/users/all`
+	);
+
+	if (!response.ok) {
+		const errorData = await response.json();
+		throw new Error(errorData.error || "Failed to fetch users");
+	}
+
+	return await response.json();
+};
+
 export const updateUser = async (userId: string, data: Partial<UserCreate>) => {
 	const response = await fetchWithRefreshAndRetry(
 		`${keys.API_URL}/users/${userId}`,

--- a/client/src/components/Admin/Users/AdminUsersDeleteModal.tsx
+++ b/client/src/components/Admin/Users/AdminUsersDeleteModal.tsx
@@ -1,0 +1,84 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { deleteUser } from "../../../api/user";
+import { ReactSetState } from "../../../types/ReactTypes";
+import { User } from "../../../types/User";
+import Modal from "../../Modal";
+
+const AdminUsersDeleteModal = ({
+	selectedUser,
+	openModalDeleteUser,
+	setOpenModalDeleteUser,
+}: {
+	selectedUser: User | null;
+	openModalDeleteUser: boolean;
+	setOpenModalDeleteUser: ReactSetState<boolean>;
+}) => {
+	const queryClient = useQueryClient();
+
+	const deleteUserMutation = useMutation({
+		mutationFn: async () => {
+			if (selectedUser?.id) {
+				return await deleteUser(selectedUser.id);
+			}
+			throw new Error("User ID is undefined");
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["users"] });
+			setOpenModalDeleteUser(false);
+			toast.success("User deleted successfully", {
+				style: {
+					padding: "16px",
+				},
+				position: "top-right",
+			});
+		},
+		onError: (error) => {
+			if (error instanceof Error) {
+				toast.error(`Failed to delete user account: ${error.message}`, {
+					style: {
+						padding: "16px",
+					},
+				});
+				return;
+			}
+			return;
+		},
+	});
+
+	return (
+		<Modal
+			isOpen={openModalDeleteUser}
+			onClose={() => setOpenModalDeleteUser(false)}
+			closeOnClickOutside={true}
+		>
+			<div id="modal-content" className="flex flex-col gap-5">
+				<p className="text-base font-semibold font-sora">Delete user</p>
+				<p className="text-sm">
+					Are you sure you want to delete the user account with the
+					username :{" "}
+					<span className="font-bold font-sora">
+						{selectedUser?.username}
+					</span>{" "}
+					? This action cannot be undone.
+				</p>
+				<div className="flex gap-4 justify-end">
+					<button
+						className="btn-danger-outline p-2"
+						onClick={() => setOpenModalDeleteUser(false)}
+					>
+						Cancel
+					</button>
+					<button
+						className="btn-danger p-2"
+						onClick={() => deleteUserMutation.mutate()}
+					>
+						Delete
+					</button>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+export default AdminUsersDeleteModal;

--- a/client/src/components/Admin/Users/AdminUsersEditModal.tsx
+++ b/client/src/components/Admin/Users/AdminUsersEditModal.tsx
@@ -1,0 +1,202 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { updateUser } from "../../../api/user";
+import { ReactSetState } from "../../../types/ReactTypes";
+import { User, UserRole } from "../../../types/User";
+import Modal from "../../Modal";
+
+const AdminUsersEditModal = ({
+	selectedUser,
+	openModalEditUser,
+	setOpenModalEditUser,
+}: {
+	selectedUser: User | null;
+	openModalEditUser: boolean;
+	setOpenModalEditUser: ReactSetState<boolean>;
+}) => {
+	const [userData, setUserData] = useState({
+		username: selectedUser?.username ?? "",
+		email: selectedUser?.email ?? "",
+		role: selectedUser?.role ?? UserRole.USER,
+	});
+	const [errors, setErrors] = useState<Record<string, string>>({});
+
+	const queryClient = useQueryClient();
+
+	const updateUserMutation = useMutation({
+		mutationFn: async (updatedUserData: Partial<typeof userData>) => {
+			if (selectedUser?.id) {
+				return await updateUser(selectedUser.id, updatedUserData);
+			}
+			throw new Error("User ID is undefined");
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["users"] });
+			setOpenModalEditUser(false);
+			toast.success("User updated successfully", {
+				style: {
+					padding: "16px",
+				},
+				position: "top-right",
+			});
+		},
+		onError: (error) => {
+			if (error instanceof Error) {
+				toast.error(
+					`Failed to update user information: ${error.message}`,
+					{
+						style: {
+							padding: "16px",
+						},
+					}
+				);
+				return;
+			}
+			setErrors(error);
+		},
+	});
+
+	const handleInputChange = (
+		e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+	) => {
+		const { name, value } = e.target;
+		setUserData((prevState) => ({
+			...prevState,
+			[name]: value,
+		}));
+
+		if (errors[name]) {
+			setErrors((prevErrors) => {
+				const newErrors = { ...prevErrors };
+				delete newErrors[name];
+				return newErrors;
+			});
+		}
+	};
+
+	const hasChanges = useMemo(() => {
+		return (
+			userData.username !== selectedUser?.username ||
+			userData.email !== selectedUser?.email ||
+			userData.role !== selectedUser?.role
+		);
+	}, [userData, selectedUser]);
+
+	const getUpdatedFields = useCallback(() => {
+		const updatedFields: Partial<typeof userData> = {};
+		if (userData.username !== selectedUser?.username)
+			updatedFields.username = userData.username;
+		if (userData.email !== selectedUser?.email)
+			updatedFields.email = userData.email;
+		if (userData.role !== selectedUser?.role)
+			updatedFields.role = userData.role;
+		return updatedFields;
+	}, [userData, selectedUser]);
+
+	const handleSave = () => {
+		if (hasChanges) {
+			const updatedFields = getUpdatedFields();
+			updateUserMutation.mutate(updatedFields);
+		} else {
+			toast.info("No changes to save", {
+				style: { padding: "16px" },
+				position: "top-right",
+			});
+		}
+	};
+
+	return (
+		<Modal
+			isOpen={openModalEditUser}
+			onClose={() => setOpenModalEditUser(false)}
+			closeOnClickOutside={true}
+		>
+			<div id="modal-content" className="flex flex-col gap-5">
+				<div className="flex flex-col gap-4">
+					<p className="text-base font-semibold font-sora s-sm:text-lg">
+						Edit User
+					</p>
+				</div>
+				<div className="w-full flex flex-col gap-4">
+					<div>
+						<label htmlFor="username" className="">
+							Username
+						</label>
+						<input
+							id="username"
+							type="text"
+							name="username"
+							value={userData.username}
+							onChange={handleInputChange}
+							className="mt-1 block w-full px-3 py-1 border-2 rounded-md shadow-sm"
+						/>
+						{errors.username && (
+							<p className="text-danger-light-3 text-sm mt-2">
+								{errors.username}
+							</p>
+						)}
+					</div>
+
+					<div>
+						<label htmlFor="email" className="">
+							Email
+						</label>
+						<input
+							id="email"
+							type="email"
+							name="email"
+							value={userData.email}
+							onChange={handleInputChange}
+							className="mt-1 block w-full px-3 py-1 border-2 rounded-md shadow-sm"
+						/>
+						{errors.email && (
+							<p className="text-danger-light-3 text-sm mt-2">
+								{errors.email}
+							</p>
+						)}
+					</div>
+
+					<div>
+						<label htmlFor="role" className="">
+							Rôle
+						</label>
+						<select
+							id="role"
+							name="role"
+							value={userData.role}
+							onChange={handleInputChange}
+							className="mt-1 block w-full px-3 py-1 border-2 rounded-md shadow-sm"
+						>
+							<option value={UserRole.USER}>User</option>
+							<option value={UserRole.ADMIN}>
+								Administrator
+							</option>
+						</select>
+						{errors.role && (
+							<p className="text-danger-light-3 text-sm mt-2">
+								{errors.role}
+							</p>
+						)}
+					</div>
+
+					<div className="flex flex-col gap-4">
+						<button
+							className="btn-primary flex-1 p-2"
+							onClick={handleSave}
+							disabled={
+								updateUserMutation.isPending || !hasChanges
+							}
+						>
+							{updateUserMutation.isPending
+								? "Saving..."
+								: "Save"}
+						</button>
+					</div>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+export default AdminUsersEditModal;

--- a/client/src/components/Admin/Users/AdminUsersTable.tsx
+++ b/client/src/components/Admin/Users/AdminUsersTable.tsx
@@ -1,0 +1,90 @@
+import { Pencil, Trash2 } from "lucide-react";
+import { BtnUserRole } from "../../../pages/admin/AdminMain";
+import { ReactSetState } from "../../../types/ReactTypes";
+import { User, UserRole } from "../../../types/User";
+import DataTable, { Column } from "../../DataTable";
+
+interface AdminUsersTableProps {
+	usersData: User[];
+	isAuthorizedActions: (role: UserRole) => boolean;
+	setSelectedUser: ReactSetState<User | null>;
+	setOpenModalEditUser: ReactSetState<boolean>;
+	setOpenModalDeleteUser: ReactSetState<boolean>;
+}
+
+const AdminUsersTable = ({
+	usersData,
+	isAuthorizedActions,
+	setSelectedUser,
+	setOpenModalEditUser,
+	setOpenModalDeleteUser,
+}: AdminUsersTableProps) => {
+	const columns: Column<User>[] = [
+		{
+			key: "username",
+			header: "Username",
+		},
+		{
+			key: "email",
+			header: "Email",
+		},
+		{
+			key: "role",
+			header: "Role",
+		},
+		{
+			key: "createdAt",
+			header: "Created At",
+		},
+		{
+			key: "actions",
+			header: "Actions",
+		},
+	] as Column<User>[];
+
+	const renderCell = (key: keyof User | "actions", user: User) => {
+		switch (key) {
+			case "username":
+				return user.username;
+			case "email":
+				return user.email;
+			case "role":
+				return <BtnUserRole role={user.role} />;
+			case "createdAt":
+				return new Date(user.createdAt).toLocaleString();
+			case "actions":
+				return (
+					isAuthorizedActions(user.role) && (
+						<div className="flex gap-2">
+							<Pencil
+								size={30}
+								className="p-1 bg-primary-dark-1 rounded cursor-pointer hover:bg-primary-dark-3 transition-all"
+								onClick={(e) => {
+									e.stopPropagation();
+									setSelectedUser(user);
+									setOpenModalEditUser(true);
+								}}
+							/>
+
+							<Trash2
+								size={30}
+								className="p-1 bg-danger-dark-1 rounded cursor-pointer hover:bg-danger-dark-3 transition-all"
+								onClick={(e) => {
+									e.stopPropagation();
+									setSelectedUser(user);
+									setOpenModalDeleteUser(true);
+								}}
+							/>
+						</div>
+					)
+				);
+			default:
+				return "N/A";
+		}
+	};
+	return (
+		<DataTable columns={columns} data={usersData} renderCell={renderCell} />
+	);
+};
+
+export default AdminUsersTable;

--- a/client/src/components/Dashboard/Team/DashboardTeamEmpty.tsx
+++ b/client/src/components/Dashboard/Team/DashboardTeamEmpty.tsx
@@ -12,11 +12,13 @@ const DashboardTeamEmpty = () => {
 				<div className="bg-secondary-dark-6 w-full max-w-screen-lg flex flex-col p-4 gap-4 s-md:gap-6 rounded-lg shadow-md">
 					<div className="flex flex-col items-center justify-center gap-4">
 						<h2 className="text-2xl font-bold">
-							No teams created yet
+							No teams created yet or no one is selected
 						</h2>
 						<p className="text-center text-lg">
-							You haven't created any teams yet. Click the "Create
-							a team" button to get started.
+							If you haven't created any teams yet. Click the
+							"Create a team" button to get started. Or if you
+							have a team already created, select it from the
+							dropdown menu.
 						</p>
 						<button
 							className="btn btn-primary rounded-lg px-6 py-2"

--- a/client/src/components/Header/UserMenu.tsx
+++ b/client/src/components/Header/UserMenu.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import { signOut } from "../../api/auth";
 import { useAuth } from "../../contexts/AuthContext";
+import { UserRole } from "../../types/User";
 
 const UserMenu = ({ className }: { className?: string }) => {
 	const { user, setUser } = useAuth();
@@ -97,6 +98,15 @@ const UserMenu = ({ className }: { className?: string }) => {
 						>
 							Settings
 						</NavLink>
+						{user.role === UserRole.ADMIN && (
+							<NavLink
+								to="/admin"
+								className="block ps-2 py-2 hover:bg-gray-light-1"
+								onClick={() => setIsOpen(false)}
+							>
+								Admin Panel
+							</NavLink>
+						)}
 						<span
 							className="block ps-2 py-2 text-danger hover:bg-danger-dark-8 cursor-pointer"
 							onClick={handleSignOut}

--- a/client/src/contexts/GroupContext.tsx
+++ b/client/src/contexts/GroupContext.tsx
@@ -36,6 +36,9 @@ export const GroupProvider = ({ children }: { children: React.ReactNode }) => {
 		queryKey: ["groups", user?.id],
 		queryFn: () => getGroups(user?.id ?? ""),
 		enabled: !!user,
+		staleTime: 1000 * 60 * 5,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
 	});
 
 	const groups = useMemo(() => data?.groups ?? [], [data]);

--- a/client/src/contexts/TeamContext.tsx
+++ b/client/src/contexts/TeamContext.tsx
@@ -40,6 +40,9 @@ export const TeamProvider = ({ children }: { children: React.ReactNode }) => {
 		queryKey: ["teams", user?.id, selectedGroupId],
 		queryFn: () => getTeamsByGroupId(user?.id ?? "", selectedGroupId ?? ""),
 		enabled: !!user && !!selectedGroupId,
+		staleTime: 1000 * 60 * 5,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
 	});
 
 	const teams = useMemo(() => data?.teams ?? [], [data]);

--- a/client/src/pages/admin/AdminGroups.tsx
+++ b/client/src/pages/admin/AdminGroups.tsx
@@ -1,0 +1,5 @@
+const AdminGroups = () => {
+	return <div>AdminGroups</div>;
+};
+
+export default AdminGroups;

--- a/client/src/pages/admin/AdminMain.tsx
+++ b/client/src/pages/admin/AdminMain.tsx
@@ -1,0 +1,74 @@
+import { NavLink, Outlet } from "react-router-dom";
+import { UserRole } from "../../types/User";
+
+export const BtnUserRole = ({ role }: { role: UserRole }) => {
+	switch (role) {
+		case UserRole.ADMIN:
+			return (
+				<span className="font-semibold uppercase p-1 bg-danger-dark-3 rounded-sm">
+					Admin
+				</span>
+			);
+		case UserRole.USER:
+			return (
+				<span className="font-semibold uppercase p-1 bg-accent rounded-sm">
+					User
+				</span>
+			);
+		default:
+			return <span>Unknown</span>;
+	}
+};
+
+const AdminMain = () => {
+	return (
+		<div className="p-4 h-screen-navbar mt-16 bg-secondary-dark-7">
+			<div className="bg-secondary-dark-6 w-full max-w-screen-lg mx-auto flex flex-col gap-4 p-4 rounded-lg shadow-md">
+				<nav className="flex flex-wrap gap-4 s-md:gap-8">
+					<NavLink
+						to="/admin/users"
+						className={({ isActive }) =>
+							`px-4 py-2 rounded-md transition-colors ${
+								isActive
+									? "bg-primary text-white"
+									: "bg-secondary-dark-5 hover:bg-secondary-dark-4"
+							}`
+						}
+					>
+						Users
+					</NavLink>
+					<NavLink
+						to="/admin/groups"
+						className={({ isActive }) =>
+							`px-4 py-2 rounded-md transition-colors ${
+								isActive
+									? "bg-primary text-white"
+									: "bg-secondary-dark-5 hover:bg-secondary-dark-4"
+							}`
+						}
+					>
+						Groups
+					</NavLink>
+					<NavLink
+						to="/admin/teams"
+						className={({ isActive }) =>
+							`px-4 py-2 rounded-md transition-colors ${
+								isActive
+									? "bg-primary text-white"
+									: "bg-secondary-dark-5 hover:bg-secondary-dark-4"
+							}`
+						}
+					>
+						Teams
+					</NavLink>
+				</nav>
+
+				<div className="bg-secondary-dark-5 p-4 rounded-lg">
+					<Outlet />
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default AdminMain;

--- a/client/src/pages/admin/AdminTeams.tsx
+++ b/client/src/pages/admin/AdminTeams.tsx
@@ -1,0 +1,5 @@
+const AdminTeams = () => {
+	return <div>AdminTeams</div>;
+};
+
+export default AdminTeams;

--- a/client/src/pages/admin/AdminUsers.tsx
+++ b/client/src/pages/admin/AdminUsers.tsx
@@ -1,0 +1,102 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { getAllUsers } from "../../api/user";
+import AdminUsersDeleteModal from "../../components/Admin/Users/AdminUsersDeleteModal";
+import AdminUsersTable from "../../components/Admin/Users/AdminUsersTable";
+import { User, UserRole } from "../../types/User";
+import AdminUsersEditModal from "../../components/Admin/Users/AdminUsersEditModal";
+
+const AdminUsers = () => {
+	const [searchTerm, setSearchTerm] = useState("");
+	const [selectedUser, setSelectedUser] = useState<User | null>(null);
+	const [openModalEditUser, setOpenModalEditUser] = useState(false);
+	const [openModalDeleteUser, setOpenModalDeleteUser] = useState(false);
+
+	const {
+		data: users,
+		isLoading,
+		isError,
+		error,
+	} = useQuery({
+		queryKey: ["users"],
+		queryFn: async () => await getAllUsers(),
+		staleTime: 1000 * 60 * 5,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+	});
+
+	const isAuthorized = (userRole: UserRole) => {
+		if (userRole !== UserRole.ADMIN) {
+			return true;
+		}
+		return false;
+	};
+
+	const filteredUsers: User[] = users?.filter(
+		(user: User) =>
+			user.username.toLowerCase().includes(searchTerm.toLowerCase()) ||
+			user.email.toLowerCase().includes(searchTerm.toLowerCase())
+	);
+
+	return (
+		<>
+			<div className="space-y-4">
+				<div className="flex flex-col gap-2 s-md:flex-row justify-between items-center">
+					<h1 className="text-2xl font-bold">User Management</h1>
+					<div className="">
+						<input
+							type="text"
+							placeholder="Search for a user..."
+							className="px-4 py-2 bg-secondary-dark-4 rounded-md border border-text text-text"
+							value={searchTerm}
+							onChange={(e) => setSearchTerm(e.target.value)}
+						/>
+					</div>
+				</div>
+
+				{isLoading ? (
+					<div className="text-center py-8">Loading...</div>
+				) : isError ? (
+					<div className="text-center py-8">
+						Error:{" "}
+						{error instanceof Error
+							? "No users exist yet"
+							: "An unexpected error occurred"}
+					</div>
+				) : (
+					<div
+						id="users-list"
+						aria-label="users-list"
+						className="w-full overflow-x-auto overflow-y-auto"
+					>
+						<AdminUsersTable
+							usersData={filteredUsers}
+							isAuthorizedActions={isAuthorized}
+							setSelectedUser={setSelectedUser}
+							setOpenModalEditUser={setOpenModalEditUser}
+							setOpenModalDeleteUser={setOpenModalDeleteUser}
+						/>
+					</div>
+				)}
+			</div>
+
+			{openModalDeleteUser && (
+				<AdminUsersDeleteModal
+					openModalDeleteUser={openModalDeleteUser}
+					setOpenModalDeleteUser={setOpenModalDeleteUser}
+					selectedUser={selectedUser}
+				/>
+			)}
+
+			{openModalEditUser && (
+				<AdminUsersEditModal
+					openModalEditUser={openModalEditUser}
+					setOpenModalEditUser={setOpenModalEditUser}
+					selectedUser={selectedUser}
+				/>
+			)}
+		</>
+	);
+};
+
+export default AdminUsers;

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -33,8 +33,20 @@ export const getUser = async (req: Request, res: Response) => {
 export const getAllUsers = async (req: Request, res: Response) => {
 	try {
 		const users = await prisma.user.findMany({
-			select: { id: true, username: true, email: true, role: true },
+			select: {
+				id: true,
+				username: true,
+				email: true,
+				role: true,
+				createdAt: true,
+			},
 		});
+
+		if (!users) {
+			res.status(404).json({ error: "No users found" });
+			return;
+		}
+
 		res.status(200).json(users);
 	} catch (error) {
 		console.error("Error in getAllUsers route:", error);


### PR DESCRIPTION
frontend:
- add fetcher getAllUsers
- create modals components for deleting or editing an user and table users
- create new pages Admin
- edit DashboardTeamEmpty file to precise what to do
- add the link to AdminPanel in UserMenu if you are an admin
- adjust the cache with react query on Contexts to avoid multiple refetch
- add the new routes admin in App.tsx

backend:
- add createdAt field and handle errors no users found on getAllUsers controller function